### PR TITLE
Prevent default list delete

### DIFF
--- a/src/components/ListMenu.tsx
+++ b/src/components/ListMenu.tsx
@@ -35,13 +35,13 @@ export default function ListMenu({ user, selectList, setIsConfirmVisible, setToB
               className="listMenuOption"
             >{opt}</button>
 
-            <span
+            {opt !== `${user.name}'s List` && <span
               className="listEdit" 
               onClick={() => {
                 setIsListEditVisible(true);
                 const list = user.listOfLists.get(opt);
                 setCurrListEdit(list);
-              }}>...</span>
+              }}>...</span>}
         </li>
         )
     })


### PR DESCRIPTION
Default list should not be able to be deleted, and the title should not be editable, so I removed the delete button and edit button from the list menu for the default list.